### PR TITLE
LCAM 646 Migrate Check Review Date Logic

### DIFF
--- a/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/exception/HardshipExceptionHandler.java
+++ b/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/exception/HardshipExceptionHandler.java
@@ -1,0 +1,22 @@
+package uk.gov.justice.laa.crime.hardship.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import uk.gov.justice.laa.crime.hardship.dto.ErrorDTO;
+
+@Slf4j
+@RestControllerAdvice
+public class HardshipExceptionHandler {
+    private static ResponseEntity<ErrorDTO> buildErrorResponse(HttpStatus status, String message) {
+        return new ResponseEntity<>(ErrorDTO.builder().code(status.toString()).message(message).build(), status);
+    }
+
+    @ExceptionHandler(ValidationException.class)
+    public ResponseEntity<ErrorDTO> handleValidationException(ValidationException exception) {
+        log.error("Validation exception: {}", exception.getMessage());
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, exception.getMessage());
+    }
+}

--- a/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/exception/ValidationException.java
+++ b/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/exception/ValidationException.java
@@ -1,0 +1,19 @@
+package uk.gov.justice.laa.crime.hardship.exception;
+
+public class ValidationException extends RuntimeException {
+    public ValidationException() {
+        super();
+    }
+
+    public ValidationException(String message) {
+        super(message);
+    }
+
+    public ValidationException(Throwable rootCause) {
+        super(rootCause);
+    }
+
+    public ValidationException(String message, Throwable rootCause) {
+        super(message, rootCause);
+    }
+}

--- a/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/validation/HardshipValidator.java
+++ b/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/validation/HardshipValidator.java
@@ -1,26 +1,25 @@
 package uk.gov.justice.laa.crime.hardship.validation;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.crime.hardship.exception.ValidationException;
 
 import java.time.LocalDate;
 import java.util.Optional;
 
-@Slf4j
 @Component
 public class HardshipValidator {
 
-    private Optional<Void> checkReviewDate(LocalDate reviewDate, LocalDate initAssDate) {
-        if (reviewDate.isBefore(initAssDate)) {
+    protected Optional<Void> checkReviewDate(LocalDate reviewDate, LocalDate initialAssessmentDate) {
+        if (reviewDate.isBefore(initialAssessmentDate)) {
             throw new ValidationException("Hardship review date precedes the initial assessment date");
         }
 
         return Optional.empty();
     }
 
-    private Optional<Void> checkReviewDate(LocalDate reviewDate, LocalDate initAssDate, LocalDate fullAssDate) {
-        if (reviewDate.isBefore(fullAssDate) || reviewDate.isBefore(initAssDate)) {
+    protected Optional<Void> checkReviewDate(LocalDate reviewDate, LocalDate initialAssessmentDate,
+                                             LocalDate fullAssessmentDate) {
+        if (reviewDate.isBefore(fullAssessmentDate) || reviewDate.isBefore(initialAssessmentDate)) {
             throw new ValidationException("Hardship review date precedes the initial or full assessment dates");
         }
 

--- a/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/validation/HardshipValidator.java
+++ b/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/validation/HardshipValidator.java
@@ -1,0 +1,29 @@
+package uk.gov.justice.laa.crime.hardship.validation;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.crime.hardship.exception.ValidationException;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Slf4j
+@Component
+public class HardshipValidator {
+
+    private Optional<Void> checkReviewDate(LocalDate reviewDate, LocalDate initAssDate) {
+        if (reviewDate.isBefore(initAssDate)) {
+            throw new ValidationException("Hardship review date precedes the initial assessment date");
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<Void> checkReviewDate(LocalDate reviewDate, LocalDate initAssDate, LocalDate fullAssDate) {
+        if (reviewDate.isBefore(fullAssDate) || reviewDate.isBefore(initAssDate)) {
+            throw new ValidationException("Hardship review date precedes the initial or full assessment dates");
+        }
+
+        return Optional.empty();
+    }
+}

--- a/crime-hardship/src/test/java/uk/gov/justice/laa/crime/hardship/validation/HardshipValidatorTest.java
+++ b/crime-hardship/src/test/java/uk/gov/justice/laa/crime/hardship/validation/HardshipValidatorTest.java
@@ -15,12 +15,12 @@ public class HardshipValidatorTest {
     public final HardshipValidator hardshipValidator = new HardshipValidator();
 
     @Test
-    void givenReviewDateIsAfterInitAssDate_whenCheckReviewDateIsInvoked_thenEmptyIsReturned() {
+    void givenReviewDateIsAfterAssDate_whenCheckReviewDateIsInvoked_thenEmptyIsReturned() {
         assertThat(hardshipValidator.checkReviewDate(TODAYS_DATE, YESTERDAYS_DATE)).isEmpty();
     }
 
     @Test
-    void givenReviewDateIsBeforeInitAssDate_whenCheckReviewDateIsInvoked_thenExceptionIsRaised() {
+    void givenReviewDateIsBeforeAssDate_whenCheckReviewDateIsInvoked_thenExceptionIsRaised() {
         assertThatThrownBy(() -> hardshipValidator.checkReviewDate(YESTERDAYS_DATE, TODAYS_DATE))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining("Hardship review date precedes the initial assessment date");
@@ -34,6 +34,13 @@ public class HardshipValidatorTest {
     @Test
     void givenReviewDateIsBeforeFullAssDate_whenCheckReviewDateIsInvoked_thenExceptionIsRaised() {
         assertThatThrownBy(() -> hardshipValidator.checkReviewDate(YESTERDAYS_DATE, DAY_BEFORE_YESTERDAY_DATE, TODAYS_DATE))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Hardship review date precedes the initial or full assessment dates");
+    }
+
+    @Test
+    void givenReviewDateIsBeforeInitAssDate_whenCheckReviewDateIsInvoked_thenExceptionIsRaised() {
+        assertThatThrownBy(() -> hardshipValidator.checkReviewDate(YESTERDAYS_DATE, TODAYS_DATE, DAY_BEFORE_YESTERDAY_DATE))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining("Hardship review date precedes the initial or full assessment dates");
     }

--- a/crime-hardship/src/test/java/uk/gov/justice/laa/crime/hardship/validation/HardshipValidatorTest.java
+++ b/crime-hardship/src/test/java/uk/gov/justice/laa/crime/hardship/validation/HardshipValidatorTest.java
@@ -1,0 +1,40 @@
+package uk.gov.justice.laa.crime.hardship.validation;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.justice.laa.crime.hardship.exception.ValidationException;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class HardshipValidatorTest {
+    public static final LocalDate TODAYS_DATE = LocalDate.now();
+    public static final LocalDate YESTERDAYS_DATE = LocalDate.now().minusDays(1);
+    public static final LocalDate DAY_BEFORE_YESTERDAY_DATE = LocalDate.now().minusDays(2);
+    public final HardshipValidator hardshipValidator = new HardshipValidator();
+
+    @Test
+    void givenReviewDateIsAfterInitAssDate_whenCheckReviewDateIsInvoked_thenEmptyIsReturned() {
+        assertThat(hardshipValidator.checkReviewDate(TODAYS_DATE, YESTERDAYS_DATE)).isEmpty();
+    }
+
+    @Test
+    void givenReviewDateIsBeforeInitAssDate_whenCheckReviewDateIsInvoked_thenExceptionIsRaised() {
+        assertThatThrownBy(() -> hardshipValidator.checkReviewDate(YESTERDAYS_DATE, TODAYS_DATE))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Hardship review date precedes the initial assessment date");
+    }
+
+    @Test
+    void givenReviewDateIsAfterBothAssDates_whenCheckReviewDateIsInvoked_thenEmptyIsReturned() {
+        assertThat(hardshipValidator.checkReviewDate(TODAYS_DATE, DAY_BEFORE_YESTERDAY_DATE, YESTERDAYS_DATE)).isEmpty();
+    }
+
+    @Test
+    void givenReviewDateIsBeforeFullAssDate_whenCheckReviewDateIsInvoked_thenExceptionIsRaised() {
+        assertThatThrownBy(() -> hardshipValidator.checkReviewDate(YESTERDAYS_DATE, DAY_BEFORE_YESTERDAY_DATE, TODAYS_DATE))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Hardship review date precedes the initial or full assessment dates");
+    }
+}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-646)

Implemented private methods to be called from a more general validate method for create and update hardship endpoints that will check the supplied review date isn't chronologically before any of the assessment dates. Assuming as hardship will be moving towards being stateless that the assessment dates will be passed to the validator rather than needing to query MAATDB as currently happens for the stored procedure.

No unit tests provided as private methods, assuming this will be cover when the more general validate method is implemented.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
