### PR TITLE
LCAM-985: Upgraded crime commons version and enabled micrometer tracing

### DIFF
--- a/crime-hardship/build.gradle
+++ b/crime-hardship/build.gradle
@@ -21,7 +21,7 @@ def versions = [
 		sentryVersion			: "6.15.0",
 		springdocVersion        : "2.1.0",
 		okhttpVersion           : "4.9.3",
-		crimeCommonsVersion     : "2.6.0",
+		crimeCommonsVersion     : "2.7.0",
 		springCloudStubRunnerVersion       : "4.0.4"
 ]
 

--- a/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/CrimeHardshipApplication.java
+++ b/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/CrimeHardshipApplication.java
@@ -1,10 +1,11 @@
 package uk.gov.justice.laa.crime.hardship;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = ZipkinAutoConfiguration.class)
 @ConfigurationPropertiesScan
 public class CrimeHardshipApplication {
 

--- a/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/dto/ErrorDTO.java
+++ b/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/dto/ErrorDTO.java
@@ -6,6 +6,7 @@ import lombok.Value;
 @Value
 @Builder
 public class ErrorDTO {
+    String traceId;
     String code;
     String message;
 }

--- a/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/exception/HardshipExceptionHandler.java
+++ b/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/exception/HardshipExceptionHandler.java
@@ -1,29 +1,35 @@
 package uk.gov.justice.laa.crime.hardship.exception;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import uk.gov.justice.laa.crime.commons.exception.APIClientException;
+import uk.gov.justice.laa.crime.commons.tracing.TraceIdHandler;
 import uk.gov.justice.laa.crime.hardship.dto.ErrorDTO;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class HardshipExceptionHandler {
-    private static ResponseEntity<ErrorDTO> buildErrorResponse(HttpStatus status, String message) {
-        return new ResponseEntity<>(ErrorDTO.builder().code(status.toString()).message(message).build(), status);
+
+    private final TraceIdHandler traceIdHandler;
+
+    private static ResponseEntity<ErrorDTO> buildErrorResponse(HttpStatus status, String message, String traceId) {
+        return new ResponseEntity<>(ErrorDTO.builder().traceId(traceId).code(status.toString()).message(message).build(), status);
     }
 
     @ExceptionHandler(ValidationException.class)
     public ResponseEntity<ErrorDTO> handleValidationException(ValidationException exception) {
         log.error("Validation exception: {}", exception.getMessage());
-        return buildErrorResponse(HttpStatus.BAD_REQUEST, exception.getMessage());
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, exception.getMessage(), traceIdHandler.getTraceId());
     }
 
     @ExceptionHandler(APIClientException.class)
     public ResponseEntity<ErrorDTO> handleApiClientException(APIClientException exception) {
         log.error("API client exception: {}", exception.getMessage());
-        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage(), traceIdHandler.getTraceId());
     }
 }

--- a/crime-hardship/src/main/resources/application.yaml
+++ b/crime-hardship/src/main/resources/application.yaml
@@ -14,6 +14,9 @@ management:
     web:
       exposure:
         include: health,info,metrics,prometheus
+  tracing:
+    propagation:
+      type: w3c,b3
 
 spring:
   datasource:

--- a/crime-hardship/src/main/resources/logback.xml
+++ b/crime-hardship/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} traceId: %X{traceId:-} spanId: %X{spanId:-} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/crime-hardship/src/test/java/uk/gov/justice/laa/crime/hardship/config/CrimeHardshipTestConfiguration.java
+++ b/crime-hardship/src/test/java/uk/gov/justice/laa/crime/hardship/config/CrimeHardshipTestConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.crime.hardship.config;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
@@ -9,6 +10,7 @@ import java.time.Instant;
 import java.util.Map;
 
 @TestConfiguration
+@ComponentScan(basePackages = {"uk.gov.justice.laa.crime.commons.tracing"})
 public class CrimeHardshipTestConfiguration {
 
     static final String SUB = "sub";

--- a/crime-hardship/src/test/java/uk/gov/justice/laa/crime/hardship/controller/HardshipControllerTest.java
+++ b/crime-hardship/src/test/java/uk/gov/justice/laa/crime/hardship/controller/HardshipControllerTest.java
@@ -6,10 +6,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.justice.laa.crime.commons.exception.APIClientException;
+import uk.gov.justice.laa.crime.hardship.config.CrimeHardshipTestConfiguration;
 import uk.gov.justice.laa.crime.hardship.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.hardship.dto.HardshipReviewDTO;
 import uk.gov.justice.laa.crime.hardship.mapper.HardshipMapper;
@@ -29,6 +31,7 @@ import static uk.gov.justice.laa.crime.hardship.staticdata.enums.HardshipReviewD
 import static uk.gov.justice.laa.crime.hardship.util.RequestBuilderUtils.buildRequestGivenContent;
 
 @WebMvcTest(HardshipController.class)
+@Import(CrimeHardshipTestConfiguration.class)
 @AutoConfigureMockMvc(addFilters = false)
 class HardshipControllerTest {
 


### PR DESCRIPTION
## What

[LCAM-985](https://dsdmoj.atlassian.net/browse/LCAM-985)

Describe what you did and why.

- Upgraded to crime commons v2.7.0 to include micrometer tracing
- Updated Exception handler to include traceId in error response
- Updated application.yaml to enable micrometer tracing for Hardship
- Updated logback.xml to include traceId and spanId
- Updated controller and Integration tests

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.


[LCAM-985]: https://dsdmoj.atlassian.net/browse/LCAM-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ