### PR TITLE
LCAM 1528 Hardship Details Not Being Set to Active on Database

### DIFF
--- a/crime-hardship/build.gradle
+++ b/crime-hardship/build.gradle
@@ -19,7 +19,7 @@ def versions = [
         pitest                      : "1.16.1",
         springdocVersion            : "2.5.0",
         crimeCommonsClasses         : "3.22.0",
-        commonsModSchemas           : "1.5.0",
+        commonsModSchemas           : "1.9.0-SNAPSHOT",
         commonsRestClient           : "3.4.0",
         springCloudStubRunnerVersion: "4.1.4",
         postgresqlVersion           : "42.7.2"
@@ -32,6 +32,9 @@ configurations {
 }
 
 repositories {
+    maven {
+        url "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+    }
     mavenCentral()
 }
 

--- a/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/mapper/PersistHardshipMapper.java
+++ b/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/mapper/PersistHardshipMapper.java
@@ -86,7 +86,8 @@ public class PersistHardshipMapper implements RequestMapper<ApiPersistHardshipRe
                                     .withOtherDescription(item.getDescription())
                                     .withUserCreated(username)
                                     .withFrequency(item.getFrequency())
-                                    .withAccepted(Boolean.TRUE.equals(item.getAccepted()) ? "Y" : "N");
+                                    .withAccepted(Boolean.TRUE.equals(item.getAccepted()) ? "Y" : "N")
+                                    .withActive("Y");
 
                             if (item instanceof DeniedIncome deniedIncome) {
                                 return detail
@@ -114,7 +115,8 @@ public class PersistHardshipMapper implements RequestMapper<ApiPersistHardshipRe
                     .withDetailType(HardshipReviewDetailType.SOL_COSTS)
                     .withAmount(hardship.getSolicitorCosts().getEstimatedTotal())
                     .withFrequency(Frequency.ANNUALLY)
-                    .withAccepted("Y"));
+                    .withAccepted("Y")
+                    .withActive("Y"));
         }
         return apiHardshipDetails;
     }

--- a/crime-hardship/src/test/java/uk/gov/justice/laa/crime/hardship/mapper/PersistHardshipMapperTest.java
+++ b/crime-hardship/src/test/java/uk/gov/justice/laa/crime/hardship/mapper/PersistHardshipMapperTest.java
@@ -112,7 +112,8 @@ class PersistHardshipMapperTest {
                         .withFrequency(deniedIncome.getFrequency())
                         .withReasonNote("Hospitalisation")
                         .withUserCreated(metadata.getUserSession().getUserName())
-                        .withDetailCode(HardshipReviewDetailCode.MEDICAL_GROUNDS),
+                        .withDetailCode(HardshipReviewDetailCode.MEDICAL_GROUNDS)
+                        .withActive("Y"),
 
                 new ApiHardshipDetail()
                         .withAccepted("N")
@@ -121,13 +122,15 @@ class PersistHardshipMapperTest {
                         .withFrequency(extraExpenditure.getFrequency())
                         .withUserCreated(metadata.getUserSession().getUserName())
                         .withDetailCode(HardshipReviewDetailCode.CARDS)
-                        .withDetailReason(extraExpenditure.getReasonCode()),
+                        .withDetailReason(extraExpenditure.getReasonCode())
+                        .withActive("Y"),
 
                 new ApiHardshipDetail()
                         .withDetailType(SOL_COSTS)
                         .withAmount(hardship.getSolicitorCosts().getEstimatedTotal())
                         .withFrequency(Frequency.ANNUALLY)
                         .withAccepted("Y")
+                        .withActive("Y")
         );
 
         assertThat(reviewDetails)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1528)

- Set the new active field on ApiHardshipDetails schema to "Y" when persisting hardship reviews, so it will get picked up by maat-api and set on the database when inserting or updating hardship detail rows.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
