### PR TITLE
LCAM 1746 Null Pointer Exception When Disbursements Not Provided

### DIFF
--- a/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/service/HardshipCalculationService.java
+++ b/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/service/HardshipCalculationService.java
@@ -17,6 +17,7 @@ import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static uk.gov.justice.laa.crime.enums.HardshipReviewResult.FAIL;
@@ -48,7 +49,7 @@ public class HardshipCalculationService {
                 estimatedTotal = solicitorCosts.getRate()
                         .multiply(solicitorCosts.getHours())
                         .add(solicitorCosts.getVat())
-                        .add(solicitorCosts.getDisbursements() == null ? BigDecimal.ZERO : solicitorCosts.getDisbursements());
+                        .add(Optional.ofNullable(solicitorCosts.getDisbursements()).orElse(BigDecimal.ZERO));
                 solicitorCosts.setEstimatedTotal(estimatedTotal);
             }
             total = total.add(estimatedTotal);

--- a/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/service/HardshipCalculationService.java
+++ b/crime-hardship/src/main/java/uk/gov/justice/laa/crime/hardship/service/HardshipCalculationService.java
@@ -48,7 +48,7 @@ public class HardshipCalculationService {
                 estimatedTotal = solicitorCosts.getRate()
                         .multiply(solicitorCosts.getHours())
                         .add(solicitorCosts.getVat())
-                        .add(solicitorCosts.getDisbursements());
+                        .add(solicitorCosts.getDisbursements() == null ? BigDecimal.ZERO : solicitorCosts.getDisbursements());
                 solicitorCosts.setEstimatedTotal(estimatedTotal);
             }
             total = total.add(estimatedTotal);

--- a/crime-hardship/src/test/java/uk/gov/justice/laa/crime/hardship/service/HardshipCalculationServiceTest.java
+++ b/crime-hardship/src/test/java/uk/gov/justice/laa/crime/hardship/service/HardshipCalculationServiceTest.java
@@ -161,7 +161,6 @@ class HardshipCalculationServiceTest {
     @Test
     void givenHardshipReviewWithSolicitorCostsAndNullDisbursements_whenCalculateHardshipIsInvoked_thenHardshipResultIsReturned() {
         HardshipReview hardship = TestModelDataBuilder.getMagsHardshipReviewWithDetails(SOL_COSTS);
-
         hardship.getSolicitorCosts().setDisbursements(null);
 
         HardshipResult response =
@@ -169,12 +168,11 @@ class HardshipCalculationServiceTest {
 
         softly.assertThat(response.getPostHardshipDisposableIncome())
                 .isEqualTo(BigDecimal.valueOf(-5250.0).setScale(2, RoundingMode.HALF_UP));
-
         softly.assertThat(response.getResult())
                 .isEqualTo(HardshipReviewResult.PASS);
-
         softly.assertThat(response.getResultDate())
                 .isEqualTo(LocalDate.now());
+        softly.assertAll();
     }
 
     @Test

--- a/crime-hardship/src/test/java/uk/gov/justice/laa/crime/hardship/service/HardshipCalculationServiceTest.java
+++ b/crime-hardship/src/test/java/uk/gov/justice/laa/crime/hardship/service/HardshipCalculationServiceTest.java
@@ -159,6 +159,25 @@ class HardshipCalculationServiceTest {
     }
 
     @Test
+    void givenHardshipReviewWithSolicitorCostsAndNullDisbursements_whenCalculateHardshipIsInvoked_thenHardshipResultIsReturned() {
+        HardshipReview hardship = TestModelDataBuilder.getMagsHardshipReviewWithDetails(SOL_COSTS);
+
+        hardship.getSolicitorCosts().setDisbursements(null);
+
+        HardshipResult response =
+                hardshipCalculationService.calculateHardship(hardship, FULL_THRESHOLD);
+
+        softly.assertThat(response.getPostHardshipDisposableIncome())
+                .isEqualTo(BigDecimal.valueOf(-5250.0).setScale(2, RoundingMode.HALF_UP));
+
+        softly.assertThat(response.getResult())
+                .isEqualTo(HardshipReviewResult.PASS);
+
+        softly.assertThat(response.getResultDate())
+                .isEqualTo(LocalDate.now());
+    }
+
+    @Test
     void givenHardshipReviewWithSolicitorCosts_whenCalculateHardshipIsInvoked_thenHardshipResultIsReturned() {
         HardshipReview hardship = TestModelDataBuilder.getMagsHardshipReviewWithDetails(SOL_COSTS);
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1746)

- Converted null disbursements to BigDecimal.ZERO when calculating estimated total solicitors costs to avoid null pointer exception.
- Added unit test to check that hardship is calculated correctly when solicitors costs with null disbursements provided.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.