### PR TITLE
Add IP allowlist to Hardship Service

### DIFF
--- a/helm_deploy/laa-crime-hardship/templates/_helpers.tpl
+++ b/helm_deploy/laa-crime-hardship/templates/_helpers.tpl
@@ -31,6 +31,16 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Create ingress configuration
+*/}}
+{{- define "laa-crime-hardship.ingress" -}}
+{{- $internalAllowlistSourceRange := (lookup "v1" "Secret" .Release.Namespace "ingress-internal-allowlist-source-range").data.INTERNAL_ALLOWLIST_SOURCE_RANGE | b64dec }}
+{{- if $internalAllowlistSourceRange }}
+  nginx.ingress.kubernetes.io/whitelist-source-range: {{ $internalAllowlistSourceRange }}
+{{- end }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "laa-crime-hardship.labels" -}}

--- a/helm_deploy/laa-crime-hardship/templates/ingress.yaml
+++ b/helm_deploy/laa-crime-hardship/templates/ingress.yaml
@@ -17,6 +17,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- include "laa-crime-hardship.ingress" . | nindent 2 }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls }}


### PR DESCRIPTION
This PR adds an IP allowlist to the Hardship Service for internal ingress.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-4143)
