### PR TITLE
LASB 4178 Upgraded to Java 21

### DIFF
--- a/crime-hardship/Dockerfile
+++ b/crime-hardship/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17-alpine
+FROM amazoncorretto:21-alpine
 RUN mkdir -p /opt/laa-crime-hardship/
 WORKDIR /opt/laa-crime-hardship/
 COPY ./build/libs/crime-hardship.jar /opt/laa-crime-hardship/app.jar

--- a/crime-hardship/build.gradle
+++ b/crime-hardship/build.gradle
@@ -10,8 +10,8 @@ plugins {
 group = "uk.gov.justice.laa.crime"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 def versions = [
@@ -78,7 +78,7 @@ dependencies {
 }
 
 jacoco {
-    toolVersion = "0.8.8"
+    toolVersion = "0.8.13"
 }
 
 test {


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/LASB/boards/454?selectedIssue=LASB-4178)

- Upgraded to use Java version 21 for container image, build process and pipeline.
- Upgraded Jacoco plugin to version compatible with Java 21

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.