### PR TITLE
Set securityContext property for containers

### DIFF
--- a/helm_deploy/laa-crime-hardship/values-dev.yaml
+++ b/helm_deploy/laa-crime-hardship/values-dev.yaml
@@ -98,3 +98,11 @@ scheduledDowntime:
 
 logging:
   level: DEBUG
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault

--- a/helm_deploy/laa-crime-hardship/values-prod.yaml
+++ b/helm_deploy/laa-crime-hardship/values-prod.yaml
@@ -77,3 +77,11 @@ scheduledDowntime:
 
 logging:
   level: INFO
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault

--- a/helm_deploy/laa-crime-hardship/values-test.yaml
+++ b/helm_deploy/laa-crime-hardship/values-test.yaml
@@ -98,3 +98,11 @@ scheduledDowntime:
 
 logging:
   level: INFO
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault

--- a/helm_deploy/laa-crime-hardship/values-uat.yaml
+++ b/helm_deploy/laa-crime-hardship/values-uat.yaml
@@ -98,3 +98,11 @@ scheduledDowntime:
 
 logging:
   level: INFO
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault


### PR DESCRIPTION
This PR sets the `securityContext` property and associated values for the app containers. This should remove the warnings currently raised when running `helm upgrade` during deployment and improve the security of the running containers.

Specifically, it sets the `allowPrivilegeEscalation`, `capabilities`, `runAsNonRoot` and `seccompProfile` settings to those values recommended by Helm (raised as warnings) when running `helm upgrade` during deployment.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3605)